### PR TITLE
Organize dataset pipeline follow-ups

### DIFF
--- a/crates/tessara-api/src/datasets/mod.rs
+++ b/crates/tessara-api/src/datasets/mod.rs
@@ -17,6 +17,7 @@ use tessara_datasets::DatasetGrain;
 use uuid::Uuid;
 
 mod dto;
+mod restriction_tiers;
 
 pub use dto::{
     CreateDatasetRequest, DatasetAggregationRequest, DatasetCalculatedFieldRequest,
@@ -31,6 +32,10 @@ use crate::{
     db::AppState,
     error::{ApiError, ApiResult},
     hierarchy::{IdResponse, require_text},
+};
+use restriction_tiers::{
+    effective_restriction_tier_sql, greatest_restriction_tier_sql, max_restriction_tier_sql,
+    tier_access_predicate,
 };
 
 pub(crate) fn routes() -> Router<AppState> {
@@ -1917,83 +1922,6 @@ fn row_filters_sql(filters: &[ValidatedRowFilter]) -> String {
     format!("\n            WHERE {predicates}")
 }
 
-fn restriction_policy_tier_sql(restriction_policy: &ValidatedRestrictionPolicy) -> String {
-    let internal_predicate = restriction_policy
-        .internal_field_key
-        .as_deref()
-        .map(boolean_tier_predicate_sql)
-        .unwrap_or_else(|| "FALSE".to_string());
-    let restricted_predicate = restriction_policy
-        .restricted_field_key
-        .as_deref()
-        .map(boolean_tier_predicate_sql)
-        .unwrap_or_else(|| "FALSE".to_string());
-    let confidential_predicate = restriction_policy
-        .confidential_field_key
-        .as_deref()
-        .map(boolean_tier_predicate_sql)
-        .unwrap_or_else(|| "FALSE".to_string());
-
-    format!(
-        r#"CASE
-                    WHEN {confidential_predicate} THEN 'confidential'
-                    WHEN {restricted_predicate} THEN 'restricted'
-                    WHEN {internal_predicate} THEN 'internal'
-                    ELSE 'public'
-                END"#
-    )
-}
-
-fn effective_restriction_tier_sql(restriction_policy: &ValidatedRestrictionPolicy) -> String {
-    greatest_restriction_tier_sql(&[
-        quote_identifier("__restriction_tier"),
-        restriction_policy_tier_sql(restriction_policy),
-    ])
-}
-
-fn greatest_restriction_tier_sql(expressions: &[String]) -> String {
-    let rank_args = expressions
-        .iter()
-        .map(|expression| restriction_tier_rank_sql(expression))
-        .collect::<Vec<_>>()
-        .join(", ");
-    format!(
-        r#"CASE GREATEST({rank_args})
-                    WHEN 3 THEN 'confidential'
-                    WHEN 2 THEN 'restricted'
-                    WHEN 1 THEN 'internal'
-                    ELSE 'public'
-                END"#
-    )
-}
-
-fn max_restriction_tier_sql(expression: &str) -> String {
-    format!(
-        r#"CASE COALESCE(MAX({}), 0)
-                    WHEN 3 THEN 'confidential'
-                    WHEN 2 THEN 'restricted'
-                    WHEN 1 THEN 'internal'
-                    ELSE 'public'
-                END"#,
-        restriction_tier_rank_sql(expression)
-    )
-}
-
-fn restriction_tier_rank_sql(expression: &str) -> String {
-    format!(
-        r#"CASE {expression}
-                    WHEN 'confidential' THEN 3
-                    WHEN 'restricted' THEN 2
-                    WHEN 'internal' THEN 1
-                    ELSE 0
-                END"#
-    )
-}
-
-fn boolean_tier_predicate_sql(field_key: &str) -> String {
-    boolean_expression_sql(&quote_identifier(field_key))
-}
-
 fn validate_dataset_row_filters(
     mut requests: Vec<DatasetRowFilterRequest>,
     fields: &[ValidatedDatasetField],
@@ -3523,16 +3451,6 @@ async fn load_materialized_dataset_table_rows(
     Ok(table_rows)
 }
 
-fn tier_access_predicate(account: &auth::AccountContext) -> &'static str {
-    if account.has_capability("admin:all") || account.has_capability("datasets:read_confidential") {
-        "TRUE"
-    } else if account.has_capability("datasets:read_restricted") {
-        "COALESCE(\"__restriction_tier\", 'public') IN ('public', 'internal', 'restricted')"
-    } else {
-        "COALESCE(\"__restriction_tier\", 'public') IN ('public', 'internal')"
-    }
-}
-
 async fn require_dataset_slug_available(pool: &sqlx::PgPool, slug: &str) -> ApiResult<()> {
     let exists: bool = sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM datasets WHERE slug = $1)")
         .bind(slug)
@@ -4036,7 +3954,7 @@ mod tests {
             confidential_field_key: Some("is_confidential".into()),
         };
 
-        let sql = restriction_policy_tier_sql(&policy);
+        let sql = restriction_tiers::restriction_policy_tier_sql(&policy);
         let confidential = sql.find("confidential").expect("confidential branch");
         let restricted = sql.find("restricted").expect("restricted branch");
         let internal = sql.find("internal").expect("internal branch");
@@ -4150,6 +4068,33 @@ mod tests {
         assert_eq!(
             activity_mapping.right_key.as_deref(),
             Some("source_3__activity_summary")
+        );
+    }
+
+    #[test]
+    fn golden_catalog_union_merge_matches_editor_contract() {
+        let left = vec![
+            source_field("source_1", "activity_summary", "text"),
+            source_field("source_1", "expected_attendees", "number"),
+        ];
+        let right = vec![
+            source_field("source_3", "activity_summary", "text"),
+            source_field("source_3", "focus_tags", "multi_choice"),
+        ];
+
+        let (fields, _) =
+            union_field_catalog(&left, &right, "union_2").expect("compatible union catalog");
+
+        assert_eq!(
+            fields
+                .iter()
+                .map(|field| (field.key.as_str(), field.field_type.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("union_2__activity_summary", "text"),
+                ("source_1__expected_attendees", "number"),
+                ("source_3__focus_tags", "multi_choice"),
+            ]
         );
     }
 
@@ -4570,6 +4515,56 @@ mod tests {
 
         assert_eq!(spec.fields()[0].key, "average_score");
         assert_eq!(spec.fields()[0].field_type, "number");
+    }
+
+    #[tokio::test]
+    async fn golden_catalog_projection_aggregation_calculation_matches_editor_contract() {
+        let mut spec = QuerySpecBuilder::new_for_test(
+            vec![
+                r#"source_1 AS (SELECT "__row_id", "__restriction_tier", "source_1__expected_attendees")"#.into(),
+            ],
+            "source_1".into(),
+            vec![source_field("source_1", "expected_attendees", "number")],
+            1,
+        );
+
+        spec.apply_operations(&positioned_operations(vec![
+            projection_operation(vec![projection_field(
+                "expected_attendees",
+                "source_1__expected_attendees",
+            )]),
+            DatasetOperationRequest::Aggregation {
+                group_fields: Vec::new(),
+                metrics: vec![dto::DatasetAggregationMetricRequest {
+                    key: "attendee_total".into(),
+                    label: "Attendee Total".into(),
+                    function: "sum".into(),
+                    source_field_key: Some("expected_attendees".into()),
+                    position: 0,
+                }],
+                row_picker: None,
+                position: 0,
+            },
+            calculated_field_operation(
+                "attendee_total_plus_one",
+                "attendee_total",
+                "add",
+                Some("1"),
+            ),
+        ]))
+        .await
+        .expect("golden catalog pipeline should validate");
+
+        assert_eq!(
+            spec.fields()
+                .iter()
+                .map(|field| (field.key.as_str(), field.field_type.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("attendee_total", "number"),
+                ("attendee_total_plus_one", "number"),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/crates/tessara-api/src/datasets/restriction_tiers.rs
+++ b/crates/tessara-api/src/datasets/restriction_tiers.rs
@@ -1,0 +1,127 @@
+//! Restriction-tier SQL helpers.
+//!
+//! Dataset row tiers are ordered by sensitivity:
+//! `confidential > restricted > internal > public`.
+
+use crate::auth;
+
+use super::{ValidatedRestrictionPolicy, boolean_expression_sql, quote_identifier};
+
+pub(super) fn restriction_policy_tier_sql(
+    restriction_policy: &ValidatedRestrictionPolicy,
+) -> String {
+    let internal_predicate = restriction_policy
+        .internal_field_key
+        .as_deref()
+        .map(boolean_tier_predicate_sql)
+        .unwrap_or_else(|| "FALSE".to_string());
+    let restricted_predicate = restriction_policy
+        .restricted_field_key
+        .as_deref()
+        .map(boolean_tier_predicate_sql)
+        .unwrap_or_else(|| "FALSE".to_string());
+    let confidential_predicate = restriction_policy
+        .confidential_field_key
+        .as_deref()
+        .map(boolean_tier_predicate_sql)
+        .unwrap_or_else(|| "FALSE".to_string());
+
+    format!(
+        r#"CASE
+                    WHEN {confidential_predicate} THEN 'confidential'
+                    WHEN {restricted_predicate} THEN 'restricted'
+                    WHEN {internal_predicate} THEN 'internal'
+                    ELSE 'public'
+                END"#
+    )
+}
+
+pub(super) fn effective_restriction_tier_sql(
+    restriction_policy: &ValidatedRestrictionPolicy,
+) -> String {
+    greatest_restriction_tier_sql(&[
+        quote_identifier("__restriction_tier"),
+        restriction_policy_tier_sql(restriction_policy),
+    ])
+}
+
+pub(super) fn greatest_restriction_tier_sql(expressions: &[String]) -> String {
+    let rank_args = expressions
+        .iter()
+        .map(|expression| restriction_tier_rank_sql(expression))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        r#"CASE GREATEST({rank_args})
+                    WHEN 3 THEN 'confidential'
+                    WHEN 2 THEN 'restricted'
+                    WHEN 1 THEN 'internal'
+                    ELSE 'public'
+                END"#
+    )
+}
+
+pub(super) fn max_restriction_tier_sql(expression: &str) -> String {
+    format!(
+        r#"CASE COALESCE(MAX({}), 0)
+                    WHEN 3 THEN 'confidential'
+                    WHEN 2 THEN 'restricted'
+                    WHEN 1 THEN 'internal'
+                    ELSE 'public'
+                END"#,
+        restriction_tier_rank_sql(expression)
+    )
+}
+
+pub(super) fn tier_access_predicate(account: &auth::AccountContext) -> &'static str {
+    if account.has_capability("admin:all") || account.has_capability("datasets:read_confidential") {
+        "TRUE"
+    } else if account.has_capability("datasets:read_restricted") {
+        "COALESCE(\"__restriction_tier\", 'public') IN ('public', 'internal', 'restricted')"
+    } else {
+        "COALESCE(\"__restriction_tier\", 'public') IN ('public', 'internal')"
+    }
+}
+
+fn boolean_tier_predicate_sql(field_key: &str) -> String {
+    boolean_expression_sql(&quote_identifier(field_key))
+}
+
+fn restriction_tier_rank_sql(expression: &str) -> String {
+    format!(
+        r#"CASE {expression}
+                    WHEN 'confidential' THEN 3
+                    WHEN 'restricted' THEN 2
+                    WHEN 'internal' THEN 1
+                    ELSE 0
+                END"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn account_without_tier_capability() -> auth::AccountContext {
+        auth::AccountContext {
+            account_id: Uuid::nil(),
+            email: "test@example.com".into(),
+            display_name: "Test User".into(),
+            is_active: true,
+            roles: Vec::new(),
+            capabilities: Vec::new(),
+            capability_scopes: Vec::new(),
+            scope_nodes: Vec::new(),
+            delegations: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn tier_access_predicate_defaults_to_public_and_internal_rows() {
+        assert_eq!(
+            tier_access_predicate(&account_without_tier_capability()),
+            "COALESCE(\"__restriction_tier\", 'public') IN ('public', 'internal')"
+        );
+    }
+}

--- a/crates/tessara-api/tests/demo_flow.rs
+++ b/crates/tessara-api/tests/demo_flow.rs
@@ -10,6 +10,14 @@ use tessara_api::{config::Config, db, router};
 use tower::ServiceExt;
 use tracing_subscriber::EnvFilter;
 
+#[path = "support/datasets.rs"]
+mod dataset_support;
+
+use dataset_support::{
+    aggregation_operation, calculated_fields_operation, detail_payload_for_restricted_tier,
+    filter_operation, projection_operation,
+};
+
 static TEST_DATABASE_LOCK: LazyLock<tokio::sync::Mutex<()>> =
     LazyLock::new(|| tokio::sync::Mutex::new(()));
 static TEST_TRACING: LazyLock<()> = LazyLock::new(|| {
@@ -21,131 +29,6 @@ static TEST_TRACING: LazyLock<()> = LazyLock::new(|| {
         .with_test_writer()
         .try_init();
 });
-
-fn detail_payload_for_restricted_tier(
-    form_id: &str,
-    form_version_id: &str,
-    visibility_node_id: &str,
-    field_key: &str,
-    field_label: &str,
-    restricted_flag_key: &str,
-    restricted_flag_label: &str,
-) -> Value {
-    json!({
-        "name": "Query Designer Restricted Dataset",
-        "slug": "query-designer-restricted-dataset",
-        "grain": "submission",
-        "visibility_node_ids": [visibility_node_id],
-        "initial_source": {
-            "kind": "form",
-            "alias": "form_a",
-            "form_id": form_id,
-            "form_version_id": form_version_id
-        },
-        "operations": [
-            projection_operation(json!([{
-                "key": field_key,
-                "label": field_label,
-                "source_alias": "form_a",
-                "source_field_key": field_key,
-                "position": 0
-            }, {
-                "key": restricted_flag_key,
-                "label": restricted_flag_label,
-                "source_alias": "form_a",
-                "source_field_key": restricted_flag_key,
-                "position": 1
-            }]), 0),
-            calculated_fields_operation(json!([{
-                "key": "restricted_flag",
-                "label": "Restricted Flag",
-                "base_field_key": restricted_flag_key,
-                "functions": [{
-                    "function": "constant",
-                    "argument": "true",
-                    "position": 0
-                }],
-                "position": 0
-            }]), 1)
-        ],
-        "restriction_policy": {
-            "restricted_field_key": "restricted_flag"
-        }
-    })
-}
-
-fn projection_operation(fields: Value, position: i32) -> Value {
-    let mut fields = fields
-        .as_array()
-        .cloned()
-        .expect("projection operation fields should be an array");
-    for (index, field) in fields.iter_mut().enumerate() {
-        let field_object = field
-            .as_object_mut()
-            .expect("projection field should be an object");
-        let input_field_key = field_object.get("key").cloned().unwrap_or(Value::Null);
-        if let (Some(source_alias), Some(source_field_key)) = (
-            field_object.get("source_alias").and_then(Value::as_str),
-            field_object.get("source_field_key").and_then(Value::as_str),
-        ) {
-            field_object.insert(
-                "input_field_key".into(),
-                json!(canonical_source_field_key(source_alias, source_field_key)),
-            );
-        }
-        field_object
-            .entry("input_field_key")
-            .or_insert(input_field_key);
-        field_object
-            .entry("position")
-            .or_insert_with(|| json!(index as i32));
-        field_object.remove("source_alias");
-        field_object.remove("source_field_key");
-    }
-    json!({
-        "kind": "projection",
-        "fields": fields,
-        "position": position
-    })
-}
-
-fn canonical_source_field_key(source_alias: &str, source_field_key: &str) -> String {
-    format!(
-        "{source_alias}__{}",
-        source_field_key.trim_start_matches('_')
-    )
-}
-
-fn aggregation_operation(
-    group_fields: Value,
-    metrics: Value,
-    row_picker: Value,
-    position: i32,
-) -> Value {
-    json!({
-        "kind": "aggregation",
-        "group_fields": group_fields,
-        "metrics": metrics,
-        "row_picker": row_picker,
-        "position": position
-    })
-}
-
-fn calculated_fields_operation(fields: Value, position: i32) -> Value {
-    json!({
-        "kind": "calculated_fields",
-        "fields": fields,
-        "position": position
-    })
-}
-
-fn filter_operation(filters: Value, position: i32) -> Value {
-    json!({
-        "kind": "filter",
-        "filters": filters,
-        "position": position
-    })
-}
 
 #[tokio::test]
 async fn demo_seed_uses_capability_scope_ownership_and_components() {

--- a/crates/tessara-api/tests/support/datasets.rs
+++ b/crates/tessara-api/tests/support/datasets.rs
@@ -1,0 +1,126 @@
+use serde_json::{Value, json};
+
+pub fn detail_payload_for_restricted_tier(
+    form_id: &str,
+    form_version_id: &str,
+    visibility_node_id: &str,
+    field_key: &str,
+    field_label: &str,
+    restricted_flag_key: &str,
+    restricted_flag_label: &str,
+) -> Value {
+    json!({
+        "name": "Query Designer Restricted Dataset",
+        "slug": "query-designer-restricted-dataset",
+        "grain": "submission",
+        "visibility_node_ids": [visibility_node_id],
+        "initial_source": {
+            "kind": "form",
+            "alias": "form_a",
+            "form_id": form_id,
+            "form_version_id": form_version_id
+        },
+        "operations": [
+            projection_operation(json!([{
+                "key": field_key,
+                "label": field_label,
+                "source_alias": "form_a",
+                "source_field_key": field_key,
+                "position": 0
+            }, {
+                "key": restricted_flag_key,
+                "label": restricted_flag_label,
+                "source_alias": "form_a",
+                "source_field_key": restricted_flag_key,
+                "position": 1
+            }]), 0),
+            calculated_fields_operation(json!([{
+                "key": "restricted_flag",
+                "label": "Restricted Flag",
+                "base_field_key": restricted_flag_key,
+                "functions": [{
+                    "function": "constant",
+                    "argument": "true",
+                    "position": 0
+                }],
+                "position": 0
+            }]), 1)
+        ],
+        "restriction_policy": {
+            "restricted_field_key": "restricted_flag"
+        }
+    })
+}
+
+pub fn projection_operation(fields: Value, position: i32) -> Value {
+    let mut fields = fields
+        .as_array()
+        .cloned()
+        .expect("projection operation fields should be an array");
+    for (index, field) in fields.iter_mut().enumerate() {
+        let field_object = field
+            .as_object_mut()
+            .expect("projection field should be an object");
+        let input_field_key = field_object.get("key").cloned().unwrap_or(Value::Null);
+        if let (Some(source_alias), Some(source_field_key)) = (
+            field_object.get("source_alias").and_then(Value::as_str),
+            field_object.get("source_field_key").and_then(Value::as_str),
+        ) {
+            field_object.insert(
+                "input_field_key".into(),
+                json!(canonical_source_field_key(source_alias, source_field_key)),
+            );
+        }
+        field_object
+            .entry("input_field_key")
+            .or_insert(input_field_key);
+        field_object
+            .entry("position")
+            .or_insert_with(|| json!(index as i32));
+        field_object.remove("source_alias");
+        field_object.remove("source_field_key");
+    }
+    json!({
+        "kind": "projection",
+        "fields": fields,
+        "position": position
+    })
+}
+
+pub fn canonical_source_field_key(source_alias: &str, source_field_key: &str) -> String {
+    format!(
+        "{source_alias}__{}",
+        source_field_key.trim_start_matches('_')
+    )
+}
+
+pub fn aggregation_operation(
+    group_fields: Value,
+    metrics: Value,
+    row_picker: Value,
+    position: i32,
+) -> Value {
+    json!({
+        "kind": "aggregation",
+        "group_fields": group_fields,
+        "metrics": metrics,
+        "row_picker": row_picker,
+        "position": position
+    })
+}
+
+pub fn calculated_fields_operation(fields: Value, position: i32) -> Value {
+    json!({
+        "kind": "calculated_fields",
+        "fields": fields,
+        "position": position
+    })
+}
+
+pub fn filter_operation(filters: Value, position: i32) -> Value {
+    json!({
+        "kind": "filter",
+        "filters": filters,
+        "position": position
+    })
+}

--- a/crates/tessara-web/src/features/datasets/editor/operations.rs
+++ b/crates/tessara-web/src/features/datasets/editor/operations.rs
@@ -1308,6 +1308,13 @@ mod tests {
         fields.into_iter().map(|field| field.key).collect()
     }
 
+    fn field_key_types(fields: Vec<DatasetFieldDraft>) -> Vec<(String, String)> {
+        fields
+            .into_iter()
+            .map(|field| (field.key, field.field_type))
+            .collect()
+    }
+
     #[test]
     fn union_catalog_merges_compatible_source_fields() {
         let current_fields = vec![catalog_field("source_1", "activity_summary", "text")];
@@ -1323,6 +1330,35 @@ mod tests {
             vec![
                 "union_2__activity_summary".to_string(),
                 "source_3__delivery_mode".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn golden_catalog_union_merge_matches_backend_contract() {
+        let current_fields = vec![
+            catalog_field("source_1", "activity_summary", "text"),
+            catalog_field("source_1", "expected_attendees", "number"),
+        ];
+        let next_fields = vec![
+            catalog_field("source_3", "activity_summary", "text"),
+            catalog_field("source_3", "focus_tags", "multi_choice"),
+        ];
+
+        let merged = merge_union_catalog(current_fields, next_fields, 2);
+
+        assert_eq!(
+            field_key_types(merged),
+            vec![
+                ("union_2__activity_summary".to_string(), "text".to_string()),
+                (
+                    "source_1__expected_attendees".to_string(),
+                    "number".to_string()
+                ),
+                (
+                    "source_3__focus_tags".to_string(),
+                    "multi_choice".to_string()
+                ),
             ]
         );
     }
@@ -1549,6 +1585,51 @@ mod tests {
             vec![calculation],
         ));
         assert!(keys.contains(&"is_confidential".into()));
+    }
+
+    #[test]
+    fn golden_catalog_projection_aggregation_calculation_matches_backend_contract() {
+        let (initial_source, forms, rendered_forms) = catalog_fixture();
+        let mut projection = DatasetOperationDraft::new(1, DatasetOperationDraftKind::Projection);
+        projection.projection_fields = vec![DatasetFieldDraft {
+            key: "expected_attendees".into(),
+            label: "Expected Attendees".into(),
+            source_alias: "program".into(),
+            source_field_key: "participant_target".into(),
+            field_type: "number".into(),
+        }];
+        let mut aggregation = DatasetOperationDraft::new(2, DatasetOperationDraftKind::Aggregation);
+        aggregation.aggregation = DatasetAggregationDraft {
+            enabled: true,
+            group_fields: Vec::new(),
+            metrics: vec![metric(1, "attendee_total", "expected_attendees")],
+            row_picker: None,
+        };
+        let mut calculation =
+            DatasetOperationDraft::new(3, DatasetOperationDraftKind::CalculatedFields);
+        calculation.calculated_fields = vec![calculated_field(
+            1,
+            "attendee_total_plus_one",
+            "attendee_total",
+            "add",
+            "1",
+        )];
+
+        let fields = catalog_after_operations(
+            initial_source,
+            Vec::new(),
+            forms,
+            rendered_forms,
+            vec![projection, aggregation, calculation],
+        );
+
+        assert_eq!(
+            field_key_types(fields),
+            vec![
+                ("attendee_total".to_string(), "number".to_string()),
+                ("attendee_total_plus_one".to_string(), "number".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/docs/sprints/sprint-3c-follow-up-notes.md
+++ b/docs/sprints/sprint-3c-follow-up-notes.md
@@ -2,13 +2,13 @@
 
 These notes capture post-PR #100 organization and hardening work that should not block the Sprint 3C merge. They preserve the trigger for each item so future planning can pull work forward when it becomes materially useful.
 
-## Immediate Follow-Up
+## Completed Follow-Up
 
 ### Centralize Restriction-Tier Semantics
 
 Trigger: the next change that touches dataset row-tier behavior, tier access predicates, or restriction policy SQL.
 
-Plan: move restriction-tier ordering, rank SQL, greatest/max tier SQL, policy CASE SQL, and access predicates into one helper/module. Keep the current ordering `confidential > restricted > internal > public` and preserve existing tests.
+Status: implemented in `crates/tessara-api/src/datasets/restriction_tiers.rs`.
 
 Validation: run dataset compiler unit tests, `demo_flow`, and API clippy.
 
@@ -16,7 +16,7 @@ Validation: run dataset compiler unit tests, `demo_flow`, and API clippy.
 
 Trigger: the next dataset editor or compiler change that affects available fields, output fields, source catalogs, joins, unions, projections, aggregations, calculated fields, filters, or restriction field options.
 
-Plan: add paired backend/frontend test scenarios that assert the backend compiler and frontend editor catalog simulation produce matching field keys/types for representative pipelines. Prioritize dataset-source revision fields, compatible unions, joins, projection renames, aggregation plus calculated fields, and mixed restriction tiers.
+Status: added paired backend/frontend golden catalog tests for compatible union merges and projection plus aggregation plus calculated-field pipelines.
 
 Validation: run `cargo test -p tessara-api datasets:: --lib`, `cargo test -p tessara-web --features hydrate --lib`, and the affected integration tests.
 
@@ -24,7 +24,7 @@ Validation: run `cargo test -p tessara-api datasets:: --lib`, `cargo test -p tes
 
 Trigger: the next dataset integration test that adds another reusable JSON operation builder or repeats existing dataset-authoring setup.
 
-Plan: move reusable helpers from `crates/tessara-api/tests/demo_flow.rs` into `crates/tessara-api/tests/support/datasets.rs`, keeping scenario assertions in `demo_flow.rs`.
+Status: moved reusable JSON operation builders from `crates/tessara-api/tests/demo_flow.rs` into `crates/tessara-api/tests/support/datasets.rs`, keeping scenario assertions in `demo_flow.rs`.
 
 Validation: run `cargo test -p tessara-api --test demo_flow`.
 


### PR DESCRIPTION
## Summary
- Centralizes dataset restriction-tier SQL/access helper behavior in `restriction_tiers`
- Adds paired backend/frontend golden catalog tests for union merges and projection/aggregation/calculation pipelines
- Moves reusable dataset integration-test JSON builders out of `demo_flow` into test support
- Updates Sprint 3C follow-up notes to reflect completed and deferred work

## Validation
- `cargo test -p tessara-api datasets:: --lib --jobs 2`
- `cargo test -p tessara-api --test demo_flow --jobs 2`
- `$env:RUSTFLAGS='-C debuginfo=0'; cargo test -p tessara-web --features hydrate --lib --jobs 2`
- `cargo clippy -p tessara-web --features hydrate --all-targets -- -D warnings`
- `cargo clippy -p tessara-web --no-default-features --features ssr --all-targets -- -D warnings`
- `cargo clippy -p tessara-api --all-targets -- -D warnings`